### PR TITLE
Also allow small complications on top and bottom

### DIFF
--- a/wear/src/main/java/com/vlad1m1r/watchface/WatchFace.kt
+++ b/wear/src/main/java/com/vlad1m1r/watchface/WatchFace.kt
@@ -139,6 +139,8 @@ class WatchFace : CanvasWatchFaceService() {
                 ticks.draw(canvas)
             }
             if (!mode.isAmbient || dataProvider.hasComplicationsInAmbientMode()) {
+                val center = Point(canvas.width / 2f, canvas.height / 2f)
+                complications.setCenter(center)
                 complications.draw(canvas, System.currentTimeMillis())
             }
             hands.draw(canvas, calendar)
@@ -147,7 +149,7 @@ class WatchFace : CanvasWatchFaceService() {
 
         override fun onComplicationDataUpdate(watchFaceComplicationId: Int, data: ComplicationData?) {
             super.onComplicationDataUpdate(watchFaceComplicationId, data)
-            complications[watchFaceComplicationId].setComplicationData(data)
+            complications.setComplicationData(watchFaceComplicationId, data)
             invalidate()
         }
 

--- a/wear/src/main/java/com/vlad1m1r/watchface/utils/Complications.kt
+++ b/wear/src/main/java/com/vlad1m1r/watchface/utils/Complications.kt
@@ -26,18 +26,18 @@ val COMPLICATION_SUPPORTED_TYPES = mapOf(
         ComplicationData.TYPE_SMALL_IMAGE
     ),
     TOP_COMPLICATION_ID to intArrayOf(
+        ComplicationData.TYPE_LONG_TEXT,
         ComplicationData.TYPE_RANGED_VALUE,
         ComplicationData.TYPE_ICON,
         ComplicationData.TYPE_SHORT_TEXT,
-        ComplicationData.TYPE_SMALL_IMAGE,
-        ComplicationData.TYPE_LONG_TEXT
+        ComplicationData.TYPE_SMALL_IMAGE
     ),
     BOTTOM_COMPLICATION_ID to intArrayOf(
+        ComplicationData.TYPE_LONG_TEXT,
         ComplicationData.TYPE_RANGED_VALUE,
         ComplicationData.TYPE_ICON,
         ComplicationData.TYPE_SHORT_TEXT,
-        ComplicationData.TYPE_SMALL_IMAGE,
-        ComplicationData.TYPE_LONG_TEXT
+        ComplicationData.TYPE_SMALL_IMAGE
     )
 )
 


### PR DESCRIPTION
Hi Vladimir,
Thanks for implementing this open source watch face, I like it.
When I started to use it, I wanted to place a small complication on the bottom.. what was not possible. I think it would be useful though so I suggest to add it.

Intended changes in this pull request:
- Create new method `complications.setComplicationData()` and use it to pass `ComplicationData` to the `Complications` class
- Call `setCenter()` also in `onDraw()` so that the complications can be calculated depending on their size. When `setCenter()` is only called from `onSurfaceChanged()` it misses updates from `ComplicationData` changes. This might be optimized if required.
- Allow to choose small complications on top/bottom
- Add logic to place the small complications on top/bottom

What do you think?

Cheers
Pete
